### PR TITLE
Add background start and relay domains options

### DIFF
--- a/src/main/java/com/nilhcem/fakesmtp/core/ArgsHandler.java
+++ b/src/main/java/com/nilhcem/fakesmtp/core/ArgsHandler.java
@@ -1,6 +1,9 @@
 package com.nilhcem.fakesmtp.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -32,10 +35,19 @@ public enum ArgsHandler {
 	private static final String OPT_PORT_LONG = "port";
 	private static final String OPT_PORT_DESC = "SMTP port number";
 
+	private static final String OPT_BACKGROUNDSTART_SHORT = "b";
+	private static final String OPT_BACKGROUNDSTART_LONG = "background-start";
+	private static final String OPT_BACKGROUNDSTART_DESC = "If automatically start server (-s, --start-server), do it in background (without launching GUI)";
+
+	private static final String OPT_RELAYDOMAINS_SHORT = "r";
+	private static final String OPT_RELAYDOMAINS_LONG = "relay-domains";
+	private static final String OPT_RELAYDOMAINS_DESC = "Comma separated email domain(s) for which relay is accepted. If not specified relay to any domain. If specified, relay only to these domain(s), message for other are dropped (not saved).";
+
 	private final Options options;
 
 	private boolean startServerAtLaunch;
 	private String port;
+	private boolean backgroundStart;
 
 	/**
 	 * Handles command line arguments.
@@ -45,6 +57,8 @@ public enum ArgsHandler {
 		options.addOption(OPT_EMAILS_DIR_SHORT, OPT_EMAILS_DIR_LONG, true, OPT_EMAILS_DESC);
 		options.addOption(OPT_AUTOSTART_SHORT, OPT_AUTOSTART_LONG, false, OPT_AUTOSTART_DESC);
 		options.addOption(OPT_PORT_SHORT, OPT_PORT_LONG, true, OPT_PORT_DESC);
+		options.addOption(OPT_BACKGROUNDSTART_SHORT, OPT_BACKGROUNDSTART_LONG, false, OPT_BACKGROUNDSTART_DESC);
+		options.addOption(OPT_RELAYDOMAINS_SHORT, OPT_RELAYDOMAINS_LONG, true, OPT_EMAILS_DESC);
 	}
 
 	/**
@@ -64,6 +78,19 @@ public enum ArgsHandler {
 
 		port = cmd.getOptionValue(OPT_PORT_SHORT);
 		startServerAtLaunch = cmd.hasOption(OPT_AUTOSTART_SHORT);
+		backgroundStart = cmd.hasOption(OPT_BACKGROUNDSTART_SHORT);
+
+		String relaydomains = cmd.getOptionValue(OPT_RELAYDOMAINS_SHORT);
+		if (relaydomains != null) {
+			List<String> rd = Arrays.asList(relaydomains.split(","));
+			ArrayList<String> l = new ArrayList<String>();
+
+			for (final String str : rd) {
+				l.add(str.trim());
+			}
+
+			UIModel.INSTANCE.setRelayDomains(l);
+		}
 	}
 
 	/**
@@ -81,6 +108,14 @@ public enum ArgsHandler {
 	 */
 	public boolean shouldStartServerAtLaunch() {
 		return startServerAtLaunch;
+	}
+
+	/**
+	 * @return whether or not the SMTP server must be running in background, only if started at launch (if {@code shouldStartServerAtLaunch()} return true}).
+         * @see #shouldStartServerAtLaunch
+	 */
+	public boolean shouldStartInBackground() {
+		return (startServerAtLaunch && backgroundStart);
 	}
 
 	/**

--- a/src/main/java/com/nilhcem/fakesmtp/model/UIModel.java
+++ b/src/main/java/com/nilhcem/fakesmtp/model/UIModel.java
@@ -1,6 +1,7 @@
 package com.nilhcem.fakesmtp.model;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import com.nilhcem.fakesmtp.core.I18n;
 import com.nilhcem.fakesmtp.core.exception.BindPortException;
@@ -27,6 +28,7 @@ public enum UIModel {
 	private int nbMessageReceived = 0;
 	private String savePath = I18n.INSTANCE.get("emails.default.dir");
 	private final Map<Integer, String> listMailsMap = new HashMap<Integer, String>();
+        private List<String> relayDomains = null;
 
 	private UIModel() {
 	}
@@ -93,5 +95,13 @@ public enum UIModel {
 
 	public Map<Integer, String> getListMailsMap() {
 		return listMailsMap;
+	}
+
+	public List<String> getRelayDomains() {
+		return relayDomains;
+	}
+
+	public void setRelayDomains(List<String> relayDomains) {
+		this.relayDomains = relayDomains;
 	}
 }

--- a/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
+++ b/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
@@ -9,6 +9,7 @@ import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 import java.util.regex.Matcher;
@@ -43,6 +44,23 @@ public final class MailSaver extends Observable {
 	 * @see com.nilhcem.fakesmtp.gui.MainPanel#addObservers to see which observers will be notified
 	 */
 	public void saveEmailAndNotify(String from, String to, InputStream data) {
+		List<String> relayDomains = UIModel.INSTANCE.getRelayDomains();
+
+		if (relayDomains != null) {
+			boolean matches = false;
+			for (final String d : relayDomains) {
+				if (to.endsWith(d)) {
+					matches = true;
+					break;
+				}
+			}
+
+			if (!matches) {
+				LOGGER.debug("Destination {} doesn't match relay domains", to);
+				return;
+			}
+		}
+            
 		synchronized (getLock()) {
 			String mailContent = convertStreamToString(data);
 			String filePath = saveEmailToFile(mailContent);


### PR DESCRIPTION
If auto-start server at launch, option to do it in background (without GUI). Add relaydomains option to be able not to save/store messages according destination (to).
