### PR TITLE
Added the memory mode + improved the overall performances

### DIFF
--- a/src/main/java/com/nilhcem/fakesmtp/core/ArgsHandler.java
+++ b/src/main/java/com/nilhcem/fakesmtp/core/ArgsHandler.java
@@ -1,9 +1,6 @@
 package com.nilhcem.fakesmtp.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.List;
+import com.nilhcem.fakesmtp.model.UIModel;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -12,7 +9,10 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import com.nilhcem.fakesmtp.model.UIModel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Handles command line arguments.
@@ -44,11 +44,16 @@ public enum ArgsHandler {
 	private static final String OPT_RELAYDOMAINS_DESC = "Comma separated email domain(s) for which relay is accepted. If not specified, relays to any domain. If specified, relays only emails matching these domain(s), dropping (not saving) others";
 	private static final String OPT_RELAYDOMAINS_SEPARATOR = ",";
 
+	private static final String OPT_MEMORYMODE_SHORT = "m";
+	private static final String OPT_MEMORYMODE_LONG = "memory-mode";
+	private static final String OPT_MEMORYMODE_DESC = "Disable the persistence in order to avoid the overhead that it adds";
+
 	private final Options options;
 
 	private String port;
 	private boolean backgroundStart;
 	private boolean startServerAtLaunch;
+	private boolean memoryModeEnabled;
 
 	/**
 	 * Handles command line arguments.
@@ -60,6 +65,7 @@ public enum ArgsHandler {
 		options.addOption(OPT_PORT_SHORT, OPT_PORT_LONG, true, OPT_PORT_DESC);
 		options.addOption(OPT_BACKGROUNDSTART_SHORT, OPT_BACKGROUNDSTART_LONG, false, OPT_BACKGROUNDSTART_DESC);
 		options.addOption(OPT_RELAYDOMAINS_SHORT, OPT_RELAYDOMAINS_LONG, true, OPT_RELAYDOMAINS_DESC);
+		options.addOption(OPT_MEMORYMODE_SHORT, OPT_MEMORYMODE_LONG, false, OPT_MEMORYMODE_DESC);
 	}
 
 	/**
@@ -80,6 +86,7 @@ public enum ArgsHandler {
 		port = cmd.getOptionValue(OPT_PORT_SHORT);
 		startServerAtLaunch = cmd.hasOption(OPT_AUTOSTART_SHORT);
 		backgroundStart = cmd.hasOption(OPT_BACKGROUNDSTART_SHORT);
+		memoryModeEnabled = cmd.hasOption(OPT_MEMORYMODE_SHORT);
 
 		String relaydomains = cmd.getOptionValue(OPT_RELAYDOMAINS_SHORT);
 		if (relaydomains != null) {
@@ -119,6 +126,14 @@ public enum ArgsHandler {
 	 */
 	public String getPort() {
 		return port;
+	}
+
+   /**
+    * @return whether or not the SMTP server should disable the persistence in order to avoid the overhead that it adds. 
+    * This is particularly useful when we launch performance tests that massively send emails.
+    */
+	public boolean memoryModeEnabled() {
+	   return memoryModeEnabled;
 	}
 
 	/**

--- a/src/main/java/com/nilhcem/fakesmtp/gui/MainPanel.java
+++ b/src/main/java/com/nilhcem/fakesmtp/gui/MainPanel.java
@@ -1,13 +1,5 @@
 package com.nilhcem.fakesmtp.gui;
 
-import java.util.Observable;
-
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
-
-import net.miginfocom.swing.MigLayout;
-
 import com.nilhcem.fakesmtp.core.ArgsHandler;
 import com.nilhcem.fakesmtp.core.I18n;
 import com.nilhcem.fakesmtp.gui.info.ClearAllButton;
@@ -20,6 +12,13 @@ import com.nilhcem.fakesmtp.gui.tab.LogsPane;
 import com.nilhcem.fakesmtp.gui.tab.MailsListPane;
 import com.nilhcem.fakesmtp.server.MailSaver;
 import com.nilhcem.fakesmtp.server.SMTPServerHandler;
+import net.miginfocom.swing.MigLayout;
+
+import java.util.Observable;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
 
 /**
  * Provides the main panel of the application, which will contain all the components.
@@ -175,6 +174,10 @@ public final class MainPanel {
 
 		if (args.shouldStartServerAtLaunch()) {
 			startServerBtn.toggleButton();
+		}
+
+		if (args.memoryModeEnabled()) {
+			saveMsgTextField.get().setEnabled(false);
 		}
 	}
 

--- a/src/main/java/com/nilhcem/fakesmtp/gui/MenuBar.java
+++ b/src/main/java/com/nilhcem/fakesmtp/gui/MenuBar.java
@@ -1,5 +1,12 @@
 package com.nilhcem.fakesmtp.gui;
 
+import com.nilhcem.fakesmtp.core.ArgsHandler;
+import com.nilhcem.fakesmtp.core.Configuration;
+import com.nilhcem.fakesmtp.core.I18n;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.Desktop;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
@@ -15,12 +22,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.nilhcem.fakesmtp.core.Configuration;
-import com.nilhcem.fakesmtp.core.I18n;
 
 /**
  * Provides the menu bar of the application.
@@ -91,13 +92,17 @@ public final class MenuBar extends Observable {
 
 		JMenuItem mailsLocation = new JMenuItem(i18n.get("menubar.messages.location"));
 		mailsLocation.setMnemonic(i18n.get("menubar.mnemo.msglocation").charAt(0));
-		mailsLocation.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				setChanged();
-				notifyObservers();
-			}
-		});
+		if (ArgsHandler.INSTANCE.memoryModeEnabled()) {
+			mailsLocation.setEnabled(false);
+		} else {
+			mailsLocation.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					setChanged();
+					notifyObservers();
+				}
+			});
+		}
 
 		editMenu.add(mailsLocation);
 		return editMenu;

--- a/src/main/java/com/nilhcem/fakesmtp/gui/info/SaveMsgField.java
+++ b/src/main/java/com/nilhcem/fakesmtp/gui/info/SaveMsgField.java
@@ -1,14 +1,17 @@
 package com.nilhcem.fakesmtp.gui.info;
 
+import com.nilhcem.fakesmtp.core.ArgsHandler;
+import com.nilhcem.fakesmtp.core.I18n;
+import com.nilhcem.fakesmtp.gui.DirChooser;
+import com.nilhcem.fakesmtp.model.UIModel;
+
 import java.awt.Color;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.Observable;
 import java.util.Observer;
+
 import javax.swing.JTextField;
-import com.nilhcem.fakesmtp.core.I18n;
-import com.nilhcem.fakesmtp.gui.DirChooser;
-import com.nilhcem.fakesmtp.model.UIModel;
 
 /**
  * Text field in which will be written the path where emails will be automatically saved.
@@ -34,34 +37,36 @@ public final class SaveMsgField extends Observable implements Observer {
 		saveMsgField.setEditable(false);
 		saveMsgField.setBackground(bg);
 
-		// Add a MouseListener
-		saveMsgField.addMouseListener(new MouseListener() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-			}
+		if (!ArgsHandler.INSTANCE.memoryModeEnabled()) {
+			// Add a MouseListener
+			saveMsgField.addMouseListener(new MouseListener() {
+				@Override
+				public void mouseClicked(MouseEvent e) {
+				}
 
-			@Override
-			public void mousePressed(MouseEvent e) {
-				openFolderSelection();
-			}
+				@Override
+				public void mousePressed(MouseEvent e) {
+					openFolderSelection();
+				}
 
-			@Override
-			public void mouseReleased(MouseEvent e) {
-			}
+				@Override
+				public void mouseReleased(MouseEvent e) {
+				}
 
-			@Override
-			public void mouseEntered(MouseEvent e) {
-			}
+				@Override
+				public void mouseEntered(MouseEvent e) {
+				}
 
-			@Override
-			public void mouseExited(MouseEvent e) {
-			}
+				@Override
+				public void mouseExited(MouseEvent e) {
+				}
 
-			private void openFolderSelection() {
-				setChanged();
-				notifyObservers();
-			}
-		});
+				private void openFolderSelection() {
+					setChanged();
+					notifyObservers();
+				}
+			});
+		}
 	}
 
 	/**

--- a/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
+++ b/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
@@ -1,5 +1,15 @@
 package com.nilhcem.fakesmtp.server;
 
+import com.nilhcem.fakesmtp.core.ArgsHandler;
+import com.nilhcem.fakesmtp.core.Configuration;
+import com.nilhcem.fakesmtp.core.I18n;
+import com.nilhcem.fakesmtp.model.EmailModel;
+import com.nilhcem.fakesmtp.model.UIModel;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -15,15 +25,6 @@ import java.util.Observable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.nilhcem.fakesmtp.core.Configuration;
-import com.nilhcem.fakesmtp.core.I18n;
-import com.nilhcem.fakesmtp.model.EmailModel;
-import com.nilhcem.fakesmtp.model.UIModel;
-
 /**
  * Saves emails and notifies components so they can refresh their views with new data.
  *
@@ -32,7 +33,10 @@ import com.nilhcem.fakesmtp.model.UIModel;
  */
 public final class MailSaver extends Observable {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MailSaver.class);
-	private final Pattern subjectPattern = Pattern.compile("^Subject: (.*)$");
+	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+	// This can be a static variable since it is Thread Safe
+	private static final Pattern SUBJECT_PATTERN = Pattern.compile("^Subject: (.*)$");
+
 	private final SimpleDateFormat dateFormat = new SimpleDateFormat("ddMMyyhhmmssSSS");
 
 	/**
@@ -40,7 +44,7 @@ public final class MailSaver extends Observable {
 	 *
 	 * @param from the user who send the email.
 	 * @param to the recipient of the email.
-	 * @param data an inputstream object containing the email.
+	 * @param data an InputStream object containing the email.
 	 * @see com.nilhcem.fakesmtp.gui.MainPanel#addObservers to see which observers will be notified
 	 */
 	public void saveEmailAndNotify(String from, String to, InputStream data) {
@@ -61,16 +65,18 @@ public final class MailSaver extends Observable {
 			}
 		}
 
+		// We move everything that we can move outside the synchronized block to limit the impact
+		EmailModel model = new EmailModel();
+		model.setFrom(from);
+		model.setTo(to);
+		String mailContent = convertStreamToString(data);
+		model.setSubject(getSubjectFromStr(mailContent));
+		model.setEmailStr(mailContent);
+
 		synchronized (getLock()) {
-			String mailContent = convertStreamToString(data);
 			String filePath = saveEmailToFile(mailContent);
 
-			EmailModel model = new EmailModel();
 			model.setReceivedDate(new Date());
-			model.setFrom(from);
-			model.setTo(to);
-			model.setSubject(getSubjectFromStr(mailContent));
-			model.setEmailStr(mailContent);
 			model.setFilePath(filePath);
 
 			setChanged();
@@ -83,7 +89,8 @@ public final class MailSaver extends Observable {
 	 */
 	public void deleteEmails() {
 		Map<Integer, String> mails = UIModel.INSTANCE.getListMailsMap();
-
+		if (ArgsHandler.INSTANCE.memoryModeEnabled())
+			return;
 		for (String value : mails.values()) {
 			File file = new File(value);
 			if (file.exists()) {
@@ -118,8 +125,8 @@ public final class MailSaver extends Observable {
 	 * These 4 lines are SubEtha SMTP additional information.
 	 * </p>
 	 *
-	 * @param is the inputstream to be converted.
-	 * @return the converted string object, containing data from the inputstream passed in parameters.
+	 * @param is the InputStream to be converted.
+	 * @return the converted string object, containing data from the InputStream passed in parameters.
 	 */
 	private String convertStreamToString(InputStream is) {
 		final long lineNbToStartCopy = 4; // Do not copy the first 4 lines (received part)
@@ -131,7 +138,7 @@ public final class MailSaver extends Observable {
 		try {
 			while ((line = reader.readLine()) != null) {
 				if (++lineNb > lineNbToStartCopy) {
-					sb.append(line + System.getProperty("line.separator"));
+					sb.append(line).append(LINE_SEPARATOR);
 				}
 			}
 		} catch (IOException e) {
@@ -147,6 +154,8 @@ public final class MailSaver extends Observable {
 	 * @return the path of the created file.
 	 */
 	private String saveEmailToFile(String mailContent) {
+		if (ArgsHandler.INSTANCE.memoryModeEnabled())
+			return null;
 		String filePath = String.format("%s%s%s", UIModel.INSTANCE.getSavePath(), File.separator,
 				dateFormat.format(new Date()));
 
@@ -186,7 +195,7 @@ public final class MailSaver extends Observable {
 
 			String line;
 			while ((line = reader.readLine()) != null) {
-				 Matcher matcher = subjectPattern.matcher(line);
+				 Matcher matcher = SUBJECT_PATTERN.matcher(line);
 				 if (matcher.matches()) {
 					 return matcher.group(1);
 				 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
 	<!-- Custom appender, for sending the SMTP logs in the swing application directly -->
 	<!-- If you modify this part, please change also the "logback.appender.name" key in the configuration.properties file -->
 	<appender name="SMTPLOGS" class="com.nilhcem.fakesmtp.log.SMTPLogsAppender" />
-	<logger name="org.subethamail.smtp.server.Session" level="DEBUG">
+	<logger name="org.subethamail.smtp.server.Session" level="INFO">
 		<appender-ref ref="SMTPLOGS" />
 	</logger>
 	<logger name="org.subethamail.smtp.server.ServerThread" level="INFO">


### PR DESCRIPTION
Feel free to apply it or not, this set of fixes allowed me to use FakeSMTP for my performance tests, without them, it could not be used in my context. I guess that FakeSMTP has not been designed to be used for performance tests but I believe that it can still be interesting for your project, once again you are free to apply it or not.
1. I added a new mode that I called "Memory Mode", the main purpose of it was to disable the persistence of the messages which is not needed in my context and which has a huge impact in term of performance. Everything allowing to change the location of the messages is disabled when the "Memory Mode" is enabled.
2. I changed the default log level of "org.subethamail.smtp.server.Session" to INFO because the DEBUG mode is really verbose so it has a significant impact in term of CPU usage
3. System.getProperty("line.separator") is now put into a constant as it is slow and never change
4. In MailSaver.saveEmailAndNotify, I moved everything that could be moved outside the synchronized block to avoid locking too long the resource and being the main application bottleneck
