### PR TITLE
Set configured email save path on start-up

### DIFF
--- a/src/main/java/com/nilhcem/fakesmtp/gui/MainFrame.java
+++ b/src/main/java/com/nilhcem/fakesmtp/gui/MainFrame.java
@@ -2,6 +2,7 @@ package com.nilhcem.fakesmtp.gui;
 
 import com.nilhcem.fakesmtp.core.Configuration;
 import com.nilhcem.fakesmtp.core.exception.UncaughtExceptionHandler;
+import com.nilhcem.fakesmtp.model.UIModel;
 import com.nilhcem.fakesmtp.server.SMTPServerHandler;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +73,7 @@ public final class MainFrame extends WindowAdapter {
 		String emailsDir = Configuration.INSTANCE.get("emails.default.dir");
 		if (emailsDir != null && !emailsDir.isEmpty()) {
 			panel.getSaveMsgTextField().get().setText(emailsDir);
+            UIModel.INSTANCE.setSavePath(emailsDir);
 		}
 
 		mainFrame.setVisible(true);


### PR DESCRIPTION
When and email save path has been configured, it is not used when re-started.
