### PR TITLE
Added a Dock Icon Badge with the number of recieved messages for OS X.

### DIFF
--- a/src/main/java/com/nilhcem/fakesmtp/gui/info/NbReceivedLabel.java
+++ b/src/main/java/com/nilhcem/fakesmtp/gui/info/NbReceivedLabel.java
@@ -9,6 +9,10 @@ import javax.swing.JLabel;
 import com.nilhcem.fakesmtp.model.UIModel;
 import com.nilhcem.fakesmtp.server.MailSaver;
 
+import com.apple.eawt.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Label class to display the number of received emails.
  *
@@ -16,6 +20,8 @@ import com.nilhcem.fakesmtp.server.MailSaver;
  * @since 1.0
  */
 public final class NbReceivedLabel implements Observer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NbReceivedLabel.class);
+
 	private final JLabel nbReceived = new JLabel("0");
 
 	/**
@@ -42,6 +48,8 @@ public final class NbReceivedLabel implements Observer {
 	 *   the number of received messages and update the {@link UIModel};</li>
 	 *   <li>If the observable element is a {@link ClearAllButton}, the method will reinitialize
 	 *   the number of received messages and update the {@link UIModel}.</li>
+     *   <li>When running on OS X the method will also update the Dock Icon with the number of
+     *   received messages.</li>
 	 * </ul>
 	 *
 	 * @param o the observable element which will notify this class.
@@ -53,10 +61,22 @@ public final class NbReceivedLabel implements Observer {
 			UIModel model = UIModel.INSTANCE;
 			int countMsg = model.getNbMessageReceived() + 1;
 			model.setNbMessageReceived(countMsg);
+            updateDockIconBadge(Integer.toString(countMsg));
 			nbReceived.setText(Integer.toString(countMsg));
 		} else if (o instanceof ClearAllButton) {
 			UIModel.INSTANCE.setNbMessageReceived(0);
+            updateDockIconBadge("");
 			nbReceived.setText("0");
 		}
 	}
+
+    private void updateDockIconBadge(String badgeValue) {
+        try {
+            Application.getApplication().setDockIconBadge(badgeValue);
+        } catch (RuntimeException e) {
+            LOGGER.debug("Error: {} - This is probably because we run on a non-Mac platform and these components are not implemented", e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error("", e);
+        }
+    }
 }


### PR DESCRIPTION
Hello!

This is a very minor change. My only concern is that I haven't had a chance to test these changes in anything other than OS X. I followed the same try-catch method of handling the OS X specific method calls that is used in com.nilhcem.fakesmtp.FakeSMTP Line 77-86. So I believe that it should be good to go. If you want to wait until I have time to confirm that this does not break anything in Windows or Linux, let me know and I will do that.

The icon in the dock should look like this when there are 3 emails in the Mails List:
![screen shot 2014-11-24 at 4 54 57 pm](https://cloud.githubusercontent.com/assets/2799849/5173934/ca45bdb0-73fa-11e4-814a-6a321d840f54.png)
The badge should not display if there are no emails in the Mails List.

I added the changes here because this looked like the only place where you are managing the Mails List count. If it would be better placed somewhere else, let me know and I will make adjustments.

Thank you!
