### PR TITLE
Issue #26: Use version 3.1.7 of subethasmtp.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,13 @@
 		</dependency>
 
 		<!-- SubEtha SMTP: easy-to-use server-side SMTP library for Java -->
-		<!-- Do not upgrade, as version 3.1.7 prevents us from restarting the SMTP server -->
-		<!-- See http://code.google.com/p/subethasmtp/issues/detail?id=48 -->
+		<!-- Warning: version 3.1.7 prevents us from restarting the SMTP server -->
+		<!-- If you need to be able to restart the server, use version 3.1.6 -->
+		<!-- See https://github.com/voodoodyne/subethasmtp/issues/75 -->
 		<dependency>
 		    <groupId>org.subethamail</groupId>
 		    <artifactId>subethasmtp</artifactId>
-		    <version>3.1.6</version>
+		    <version>3.1.7</version>
 		</dependency>
 
 		<!-- Logging: slf4j + logback -->


### PR DESCRIPTION
3.1.6 of subethasmtp has a bug where the first header is removed if you send the mail to multiple recipients.

3.1.7 of subethasmtp has a bug regarding restarting the smtp server.

Personally, the missing header is a bigger problem for me than restarting the server, hence this pull request to upgrade to 3.1.7 :)

This modification to the pom includes a comment which warns about the restarting issue, and includes a link to the issue on github (the subethasmtp lib is no longer on google code).