### PR TITLE
Update docker-maven-plugin version to 0.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
 			<plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.3.2</version>
+				<version>0.4.11</version>
 				<configuration>
 					<imageName>${docker.image}</imageName>
 					<dockerDirectory>src/main/docker</dockerDirectory>


### PR DESCRIPTION
I ran into issues running `mvn package docker:build -DskipTests` with my version of docker.

```shell
➜  FakeSMTP git:(docker-maven-plugin-0.4.11) docker -v
Docker version 1.12.0-rc2, build 906eacd, experimental
```

Updating the `docker-maven-plugin` to the latest version as of the date of this writing fixed the issue..