### PR TITLE
Use UTF-8 encoding when saving emails

### DIFF
--- a/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
+++ b/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
@@ -176,7 +176,7 @@ public final class MailSaver extends Observable {
 
 		// Copy String to file
 		try {
-			FileUtils.writeStringToFile(file, mailContent);
+			FileUtils.writeStringToFile(file, mailContent, Charset.forName(I18n.UTF8));
 		} catch (IOException e) {
 			// If we can't save file, we display the error in the SMTP logs
 			Logger smtpLogger = LoggerFactory.getLogger(org.subethamail.smtp.server.Session.class);


### PR DESCRIPTION
Hi,
I recently used FakeSMTP to look at my generated emails.
All my emails looked wrong (in Outlook), because all utf-8 characters seemed to be wrongly encoded.

Problem (and solution) is simple: FakeSMTP reads an utf-8 InputStream in method MailSaver #convertStreamToString(InputStream is), so it should also save the stream as an utf-8 file in method MailSaver#saveEmailToFile(String mailContent).

Thierry.
