### PR TITLE
Use sortable date format

### DIFF
--- a/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
+++ b/src/main/java/com/nilhcem/fakesmtp/server/MailSaver.java
@@ -37,7 +37,7 @@ public final class MailSaver extends Observable {
 	// This can be a static variable since it is Thread Safe
 	private static final Pattern SUBJECT_PATTERN = Pattern.compile("^Subject: (.*)$");
 
-	private final SimpleDateFormat dateFormat = new SimpleDateFormat("ddMMyyhhmmssSSS");
+	private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddhhmmssSSS");
 
 	/**
 	 * Saves incoming email in file system and notifies observers.


### PR DESCRIPTION
In this PR, I changed the date format from ddMMyyhhmmssSSS to yyyyMMddhhmmssSSS.  The reason for this is that sorting files by filename will now also sort them by date.  This is very practical for viewing email files in the order they were sent.