### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8-jre
 
 RUN mkdir -p /output
 


### PR DESCRIPTION
The java base Docker image is deprecated in favor of the openjdk image